### PR TITLE
refactor: Removes email from telemetry since we don't use it

### DIFF
--- a/src/app/api/api_v1/endpoints/users.py
+++ b/src/app/api/api_v1/endpoints/users.py
@@ -29,7 +29,6 @@ async def _create_user(payload: UserCreate, users: UserCRUD, requester: Union[Us
         properties={
             "login": gh_user["login"],
             "name": gh_user["name"],
-            "email": gh_user["email"],
             "twitter_username": gh_user["twitter_username"],
         },
     )


### PR DESCRIPTION
This PR removes email information from any telemetry since it's never being used. We keep the public name & Twitter handle displayed on a given GitHub profile since it arguably can't be considered sensitive information.