### PR TITLE
docs: Adds FOSSA badge for license scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Copyright (C) 2023, Quack AI.
 
 This program is licensed under the Apache License 2.0.
 See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fquack-ai%2Fcontribution-api.svg?type=large&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fquack-ai%2Fcontribution-api?ref=badge_large&issueType=license)


### PR DESCRIPTION
This PR adds a badge for license scan of all dependencies, the goal being to have both:
- transparency over license compliance
- detecting changes of this status as the project evolves