### PR TITLE
ci(dependabot): update the frequency & filter of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
     groups:
@@ -23,12 +22,14 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
-      day: "monday"
+      interval: "daily"
       time: "06:00"
       timezone: "Europe/Paris"
     reviewers:
       - "frgfm"
     assignees:
       - "frgfm"
-    open-pull-requests-limit: 10
+    allow:
+      - dependency-name: "ruff"
+      - dependency-name: "mypy"
+      - dependency-name: "pre-commit"


### PR DESCRIPTION
This PR sets updates to:
- daily for quality dev libraries
- monthly for github actions
- disabled the rest