### PR TITLE
build(deps): remove bcrypt & sqlalchemy direct deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1411,34 +1411,6 @@ pymysql = ["pymysql", "pymysql (<1)"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
-name = "sqlalchemy-utils"
-version = "0.38.3"
-description = "Various utility functions for SQLAlchemy."
-optional = false
-python-versions = "~=3.6"
-files = [
-    {file = "SQLAlchemy-Utils-0.38.3.tar.gz", hash = "sha256:9f9afba607a40455cf703adfa9846584bf26168a0c5a60a70063b70d65051f4d"},
-    {file = "SQLAlchemy_Utils-0.38.3-py3-none-any.whl", hash = "sha256:5c13b5d08adfaa85f3d4e8ec09a75136216fad41346980d02974a70a77988bf9"},
-]
-
-[package.dependencies]
-SQLAlchemy = ">=1.3"
-
-[package.extras]
-arrow = ["arrow (>=0.3.4)"]
-babel = ["Babel (>=1.3)"]
-color = ["colour (>=0.0.4)"]
-encrypted = ["cryptography (>=0.6)"]
-intervals = ["intervals (>=0.7.1)"]
-password = ["passlib (>=1.6,<2.0)"]
-pendulum = ["pendulum (>=2.0.5)"]
-phone = ["phonenumbers (>=5.9.2)"]
-test = ["Jinja2 (>=2.3)", "Pygments (>=1.2)", "backports.zoneinfo", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "isort (>=4.2.2)", "pg8000 (>=1.12.4)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
-test-all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "backports.zoneinfo", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
-timezone = ["python-dateutil"]
-url = ["furl (>=0.4.1)"]
-
-[[package]]
 name = "sqlalchemy2-stubs"
 version = "0.0.2a35"
 description = "Typing Stubs for SQLAlchemy 1.4"
@@ -1592,4 +1564,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "653d72a017730b4860893aa3ccc875fc2e833b8a0f19f555ee74b918e0c3746a"
+content-hash = "c460e69c8ac1578d0be334a66437811a88b14c2fb4f7ae411b411b43c764881d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,17 +15,15 @@ keywords = ["backend", "api", "code contribution", "guidelines"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-uvicorn = ">=0.11.1,<1.0.0"
 fastapi = ">=0.100.0,<1.0.0"
 sqlmodel = "^0.0.8"
-asyncpg = ">=0.25.0,<1.0.0"
-bcrypt = "^3.2.0"
-passlib = { version = "^1.7.4", extras = ["bcrypt"] }
-PyJWT = "^2.8.0"
 requests = "^2.20.0"
-SQLAlchemy-Utils = "^0.38.3"
-sentry-sdk = { version = "^1.14.0", extras = ["fastapi"] }
+PyJWT = "^2.8.0"
+passlib = { version = "^1.7.4", extras = ["bcrypt"] }
+uvicorn = ">=0.11.1,<1.0.0"
+asyncpg = ">=0.25.0,<1.0.0"
 alembic = "^1.8.1"
+sentry-sdk = { version = "^1.14.0", extras = ["fastapi"] }
 posthog = "^3.0.0"
 prometheus-fastapi-instrumentator = "^6.1.0"
 


### PR DESCRIPTION
This PR removes legacy dependencies (bcrypt and sqlalchemy utils).