### PR TITLE
style(ruff): bump ruff to 0.3.0 in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: debug-statements
         language_version: python3
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.2.2'
+    rev: 'v0.3.0'
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
This PR bumps ruff to 0.3.0 also in the precommit as a follow-up to #111