### PR TITLE
feat(code): embed guidelines in the code chat

### DIFF
--- a/src/tests/endpoints/test_code.py
+++ b/src/tests/endpoints/test_code.py
@@ -53,7 +53,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 @pytest.mark.asyncio()
 async def test_chat(
     async_client: AsyncClient,
-    user_session: AsyncSession,
+    guideline_session: AsyncSession,
     user_idx: Union[int, None],
     payload: Dict[str, Any],
     status_code: int,


### PR DESCRIPTION
This PR introduces the following modifications:
- embed the guidelines in the system prompt for the chat
- on the code chat route, pull the guidelines of the authenticated user before sending the request to the model
- update the test fixture