### PR TITLE
fix(dependencies): handle cases where the token isn't JWT compliant

### DIFF
--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
-from jwt import ExpiredSignatureError, InvalidSignatureError
+from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
 from jwt import decode as jwt_decode
 from pydantic import ValidationError
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -55,6 +55,12 @@ async def get_token_payload(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token has expired.",
+            headers={"WWW-Authenticate": authenticate_value},
+        )
+    except DecodeError:
+        raise HTTPException(
+            status_code=status.HTTP_406_NOT_ACCEPTABLE,
+            detail="Invalid token.",
             headers={"WWW-Authenticate": authenticate_value},
         )
 

--- a/src/tests/test_dependencies.py
+++ b/src/tests/test_dependencies.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.security import SecurityScopes
+
+from app.api.dependencies import get_token_payload
+from app.core.security import create_access_token
+
+
+@pytest.mark.parametrize(
+    ("scopes", "token", "expires_minutes", "error_code", "expected_payload"),
+    [
+        (["admin"], "", None, 406, None),
+        (["admin"], {"user_id": "123", "scopes": ["admin"]}, None, 422, None),
+        (["admin"], {"sub": "123", "scopes": ["admin"]}, -1, 401, None),
+        (["admin"], {"sub": "123", "scopes": ["admin"]}, None, None, {"user_id": 123, "scopes": ["admin"]}),
+        (["admin"], {"sub": "123", "scopes": ["user"]}, None, 403, None),
+    ],
+)
+@pytest.mark.asyncio()
+async def test_get_token_payload(scopes, token, expires_minutes, error_code, expected_payload):
+    _token = await create_access_token(token, expires_minutes) if isinstance(token, dict) else token
+    if isinstance(error_code, int):
+        with pytest.raises(HTTPException):
+            await get_token_payload(SecurityScopes(scopes), _token)
+    else:
+        payload = await get_token_payload(SecurityScopes(scopes), _token)
+        if expected_payload is not None:
+            assert payload.model_dump() == expected_payload


### PR DESCRIPTION
This PR add a catch case for payload decoding when they're not JWT compliant. It also adds several test cases